### PR TITLE
Playdate support

### DIFF
--- a/src/joystick/playdate/SDL_sysjoystick.c
+++ b/src/joystick/playdate/SDL_sysjoystick.c
@@ -30,6 +30,7 @@
 #include "../../events/SDL_keyboard_c.h"
 
 #include "pd_api.h"
+extern PlaydateAPI* pd;
 
 static int running = 0;
 static const unsigned int button_map[] = {

--- a/src/libm/e_atan2.c
+++ b/src/libm/e_atan2.c
@@ -51,7 +51,7 @@ double attribute_hidden __ieee754_atan2(double y, double x)
 {
 	double z;
 	int32_t k,m,hx,hy,ix,iy;
-	u_int32_t lx,ly;
+	uint32_t lx,ly;
 
 	EXTRACT_WORDS(hx,lx,x);
 	ix = hx&0x7fffffff;
@@ -104,7 +104,7 @@ double attribute_hidden __ieee754_atan2(double y, double x)
 	switch (m) {
 	    case 0: return       z  ;	/* atan(+,+) */
 	    case 1: {
-	    	      u_int32_t zh;
+	    	      uint32_t zh;
 		      GET_HIGH_WORD(zh,z);
 		      SET_HIGH_WORD(z,zh ^ 0x80000000);
 		    }

--- a/src/libm/e_exp.c
+++ b/src/libm/e_exp.c
@@ -106,7 +106,7 @@ double __ieee754_exp(double x)	/* default IEEE double exp */
 	double t;
 	int32_t k=0;
 	int32_t xsb;
-	u_int32_t hx;
+	uint32_t hx;
 
 	GET_HIGH_WORD(hx,x);
 	xsb = (hx>>31)&1;		/* sign bit of x */
@@ -115,7 +115,7 @@ double __ieee754_exp(double x)	/* default IEEE double exp */
     /* filter out non-finite argument */
 	if(hx >= 0x40862E42) {			/* if |x|>=709.78... */
             if(hx>=0x7ff00000) {
-	        u_int32_t lx;
+	        uint32_t lx;
 		GET_LOW_WORD(lx,x);
 		if(((hx&0xfffff)|lx)!=0)
 		     return x+x; 		/* NaN */
@@ -153,12 +153,12 @@ double __ieee754_exp(double x)	/* default IEEE double exp */
 	if(k==0) 	return one-((x*c)/(c-2.0)-x);
 	else 		y = one-((lo-(x*c)/(2.0-c))-hi);
 	if(k >= -1021) {
-	    u_int32_t hy;
+	    uint32_t hy;
 	    GET_HIGH_WORD(hy,y);
 	    SET_HIGH_WORD(y,hy+(k<<20));	/* add k to y's exponent */
 	    return y;
 	} else {
-	    u_int32_t hy;
+	    uint32_t hy;
 	    GET_HIGH_WORD(hy,y);
 	    SET_HIGH_WORD(y,hy+((k+1000)<<20));	/* add k to y's exponent */
 	    return y*twom1000;

--- a/src/libm/e_fmod.c
+++ b/src/libm/e_fmod.c
@@ -23,7 +23,7 @@ static const double one = 1.0, Zero[] = {0.0, -0.0,};
 double attribute_hidden __ieee754_fmod(double x, double y)
 {
 	int32_t n,hx,hy,hz,ix,iy,sx,i;
-	u_int32_t lx,ly,lz;
+	uint32_t lx,ly,lz;
 
 	EXTRACT_WORDS(hx,lx,x);
 	EXTRACT_WORDS(hy,ly,y);
@@ -38,7 +38,7 @@ double attribute_hidden __ieee754_fmod(double x, double y)
 	if(hx<=hy) {
 	    if((hx<hy)||(lx<ly)) return x;	/* |x|<|y| return x */
 	    if(lx==ly)
-		return Zero[(u_int32_t)sx>>31];	/* |x|=|y| return x*0*/
+		return Zero[(uint32_t)sx>>31];	/* |x|=|y| return x*0*/
 	}
 
     /* determine ix = ilogb(x) */
@@ -92,7 +92,7 @@ double attribute_hidden __ieee754_fmod(double x, double y)
 	    if(hz<0){hx = hx+hx+(lx>>31); lx = lx+lx;}
 	    else {
 	    	if((hz|lz)==0) 		/* return sign(x)*0 */
-		    return Zero[(u_int32_t)sx>>31];
+		    return Zero[(uint32_t)sx>>31];
 	    	hx = hz+hz+(lz>>31); lx = lz+lz;
 	    }
 	}
@@ -101,7 +101,7 @@ double attribute_hidden __ieee754_fmod(double x, double y)
 
     /* convert back to floating value and restore the sign */
 	if((hx|lx)==0) 			/* return sign(x)*0 */
-	    return Zero[(u_int32_t)sx>>31];
+	    return Zero[(uint32_t)sx>>31];
 	while(hx<0x00100000) {		/* normalize x */
 	    hx = hx+hx+(lx>>31); lx = lx+lx;
 	    iy -= 1;
@@ -112,7 +112,7 @@ double attribute_hidden __ieee754_fmod(double x, double y)
 	} else {		/* subnormal output */
 	    n = -1022 - iy;
 	    if(n<=20) {
-		lx = (lx>>n)|((u_int32_t)hx<<(32-n));
+		lx = (lx>>n)|((uint32_t)hx<<(32-n));
 		hx >>= n;
 	    } else if (n<=31) {
 		lx = (hx<<(32-n))|(lx>>n); hx = sx;

--- a/src/libm/e_log.c
+++ b/src/libm/e_log.c
@@ -86,7 +86,7 @@ double attribute_hidden __ieee754_log(double x)
 {
 	double hfsq,f,s,z,R,w,t1,t2,dk;
 	int32_t k,hx,i,j;
-	u_int32_t lx;
+	uint32_t lx;
 
 	EXTRACT_WORDS(hx,lx,x);
 

--- a/src/libm/e_log10.c
+++ b/src/libm/e_log10.c
@@ -62,7 +62,7 @@ double attribute_hidden __ieee754_log10(double x)
 {
 	double y,z;
 	int32_t i,k,hx;
-	u_int32_t lx;
+	uint32_t lx;
 
 	EXTRACT_WORDS(hx,lx,x);
 
@@ -76,7 +76,7 @@ double attribute_hidden __ieee754_log10(double x)
         }
 	if (hx >= 0x7ff00000) return x+x;
 	k += (hx>>20)-1023;
-	i  = ((u_int32_t)k&0x80000000)>>31;
+	i  = ((uint32_t)k&0x80000000)>>31;
         hx = (hx&0x000fffff)|((0x3ff-i)<<20);
         y  = (double)(k+i);
 	SET_HIGH_WORD(x,hx);

--- a/src/libm/e_pow.c
+++ b/src/libm/e_pow.c
@@ -106,7 +106,7 @@ double attribute_hidden __ieee754_pow(double x, double y)
 	double y1,t1,t2,r,s,t,u,v,w;
 	int32_t i,j,k,yisint,n;
 	int32_t hx,hy,ix,iy;
-	u_int32_t lx,ly;
+	uint32_t lx,ly;
 
 	EXTRACT_WORDS(hx,lx,x);
     /* x==1: 1**y = 1 (even if y is NaN) */
@@ -183,7 +183,7 @@ double attribute_hidden __ieee754_pow(double x, double y)
 	}
 
     /* (x<0)**(non-int) is NaN */
-	if(((((u_int32_t)hx>>31)-1)|yisint)==0) return (x-x)/(x-x);
+	if(((((uint32_t)hx>>31)-1)|yisint)==0) return (x-x)/(x-x);
 
     /* |y| is huge */
 	if(iy>0x41e00000) { /* if |y| > 2**31 */
@@ -254,7 +254,7 @@ double attribute_hidden __ieee754_pow(double x, double y)
 	}
 
 	s = one; /* s (sign of result -ve**odd) = -1 else = 1 */
-	if(((((u_int32_t)hx>>31)-1)|(yisint-1))==0)
+	if(((((uint32_t)hx>>31)-1)|(yisint-1))==0)
 	    s = -one;/* (-ve)**(odd int) */
 
     /* split up y into y1+y2 and compute (y1+y2)*(t1+t2) */

--- a/src/libm/e_rem_pio2.c
+++ b/src/libm/e_rem_pio2.c
@@ -71,7 +71,7 @@ int32_t attribute_hidden __ieee754_rem_pio2(double x, double *y)
 	double z=0.0,w,t,r,fn;
 	double tx[3];
 	int32_t e0,i,j,nx,n,ix,hx;
-	u_int32_t low;
+	uint32_t low;
 
 	GET_HIGH_WORD(hx,x);		/* high word of x */
 	ix = hx&0x7fffffff;
@@ -111,7 +111,7 @@ int32_t attribute_hidden __ieee754_rem_pio2(double x, double *y)
 	    if(n<32&&ix!=npio2_hw[n-1]) {
 		y[0] = r-w;	/* quick check no cancellation */
 	    } else {
-	        u_int32_t high;
+	        uint32_t high;
 	        j  = ix>>20;
 	        y[0] = r-w;
 		GET_HIGH_WORD(high,y[0]);

--- a/src/libm/e_sqrt.c
+++ b/src/libm/e_sqrt.c
@@ -89,7 +89,7 @@ double attribute_hidden __ieee754_sqrt(double x)
 	double z;
 	int32_t sign = (int)0x80000000;
 	int32_t ix0,s0,q,m,t,i;
-	u_int32_t r,t1,s1,ix1,q1;
+	uint32_t r,t1,s1,ix1,q1;
 
 	EXTRACT_WORDS(ix0,ix1,x);
 
@@ -164,9 +164,9 @@ double attribute_hidden __ieee754_sqrt(double x)
 	    z = one-tiny; /* trigger inexact flag */
 	    if (z>=one) {
 	        z = one+tiny;
-	        if (q1==(u_int32_t)0xffffffff) { q1=0; q += 1;}
+	        if (q1==(uint32_t)0xffffffff) { q1=0; q += 1;}
 		else if (z>one) {
-		    if (q1==(u_int32_t)0xfffffffe) q+=1;
+		    if (q1==(uint32_t)0xfffffffe) q+=1;
 		    q1+=2;
 		} else
 	            q1 += (q1&1);

--- a/src/libm/k_tan.c
+++ b/src/libm/k_tan.c
@@ -74,7 +74,7 @@ double attribute_hidden __kernel_tan(double x, double y, int iy)
 	ix = hx&0x7fffffff;	/* high word of |x| */
 	if(ix<0x3e300000)			/* x < 2**-28 */
 	    {if((int)x==0) {			/* generate inexact */
-	        u_int32_t low;
+	        uint32_t low;
 		GET_LOW_WORD(low,x);
 		if(((ix|low)|(iy+1))==0) return one/fabs(x);
 		else return (iy==1)? x: -one/x;

--- a/src/libm/math_private.h
+++ b/src/libm/math_private.h
@@ -28,7 +28,7 @@
 #define strong_alias(x, y)
 
 #if !defined(__HAIKU__) && !defined(__PSP__) && !defined(__3DS__) && !defined(__PS2__) && !defined(PLAYDATE) /* already defined in a system header. */
-typedef unsigned int u_int32_t;
+typedef unsigned int uint32_t;
 #endif
 
 #define atan            SDL_uclibc_atan
@@ -76,8 +76,8 @@ typedef union
     double value;
     struct
     {
-        u_int32_t msw;
-        u_int32_t lsw;
+        uint32_t msw;
+        uint32_t lsw;
     } parts;
 } ieee_double_shape_type;
 
@@ -88,8 +88,8 @@ typedef union
     double value;
     struct
     {
-        u_int32_t lsw;
-        u_int32_t msw;
+        uint32_t lsw;
+        uint32_t msw;
     } parts;
 } ieee_double_shape_type;
 
@@ -159,7 +159,7 @@ do {								\
 typedef union
 {
     float value;
-    u_int32_t word;
+    uint32_t word;
 } ieee_float_shape_type;
 
 /* Get a 32 bit int from a float.  */

--- a/src/libm/s_atan.c
+++ b/src/libm/s_atan.c
@@ -76,7 +76,7 @@ double atan(double x)
 	GET_HIGH_WORD(hx,x);
 	ix = hx&0x7fffffff;
 	if(ix>=0x44100000) {	/* if |x| >= 2^66 */
-	    u_int32_t low;
+	    uint32_t low;
 	    GET_LOW_WORD(low,x);
 	    if(ix>0x7ff00000||
 		(ix==0x7ff00000&&(low!=0)))

--- a/src/libm/s_copysign.c
+++ b/src/libm/s_copysign.c
@@ -20,7 +20,7 @@
 
 double copysign(double x, double y)
 {
-	u_int32_t hx,hy;
+	uint32_t hx,hy;
 	GET_HIGH_WORD(hx,x);
 	GET_HIGH_WORD(hy,y);
 	SET_HIGH_WORD(x,(hx&0x7fffffff)|(hy&0x80000000));

--- a/src/libm/s_fabs.c
+++ b/src/libm/s_fabs.c
@@ -21,7 +21,7 @@
 
 double fabs(double x)
 {
-	u_int32_t high;
+	uint32_t high;
 	GET_HIGH_WORD(high,x);
 	SET_HIGH_WORD(x,high&0x7fffffff);
         return x;

--- a/src/libm/s_floor.c
+++ b/src/libm/s_floor.c
@@ -33,7 +33,7 @@ static const double huge = 1.0e300;
 double floor(double x)
 {
 	int32_t i0,i1,j0;
-	u_int32_t i,j;
+	uint32_t i,j;
 	EXTRACT_WORDS(i0,i1,x);
 	j0 = ((i0>>20)&0x7ff)-0x3ff;
 	if(j0<20) {
@@ -55,14 +55,14 @@ double floor(double x)
 	    if(j0==0x400) return x+x;	/* inf or NaN */
 	    else return x;		/* x is integral */
 	} else {
-	    i = ((u_int32_t)(0xffffffff))>>(j0-20);
+	    i = ((uint32_t)(0xffffffff))>>(j0-20);
 	    if((i1&i)==0) return x;	/* x is integral */
 	    if(huge+x>0.0) { 		/* raise inexact flag */
 		if(i0<0) {
 		    if(j0==20) i0+=1;
 		    else {
 			j = i1+(1<<(52-j0));
-			if(j<(u_int32_t)i1) i0 +=1 ; 	/* got a carry */
+			if(j<(uint32_t)i1) i0 +=1 ; 	/* got a carry */
 			i1=j;
 		    }
 		}

--- a/src/power/playdate/SDL_syspower.c
+++ b/src/power/playdate/SDL_syspower.c
@@ -27,6 +27,7 @@
 #include "../SDL_syspower.h"
 
 #include "pd_api.h"
+extern PlaydateAPI* pd;
 
 SDL_bool
 SDL_GetPowerInfo_Playdate(SDL_PowerState * state, int *seconds, int *percent)

--- a/src/sensor/playdate/SDL_playdatesensor.c
+++ b/src/sensor/playdate/SDL_playdatesensor.c
@@ -30,6 +30,7 @@
 #include "../SDL_syssensor.h"
 
 #include "pd_api.h"
+extern PlaydateAPI* pd;
 
 typedef struct
 {
@@ -114,7 +115,8 @@ SDL_PLAYDATE_SensorUpdate(SDL_Sensor *sensor)
                 data[0] = data[0] * SDL_STANDARD_GRAVITY;
                 data[1] = data[1] * SDL_STANDARD_GRAVITY;
                 data[2] = data[2] * SDL_STANDARD_GRAVITY;
-                SDL_PrivateSensorUpdate(sensor, data, SDL_arraysize(data));
+            	Uint64 timestamp_us = pd->system->getCurrentTimeMilliseconds() * 1000;
+                SDL_PrivateSensorUpdate(sensor, timestamp_us, data, SDL_arraysize(data));
             }
             break;
         default:

--- a/src/timer/playdate/SDL_systimer.c
+++ b/src/timer/playdate/SDL_systimer.c
@@ -24,6 +24,7 @@
 
 #include "SDL_timer.h"
 #include "pd_api.h"
+extern PlaydateAPI* pd;
 
 static SDL_bool ticks_started = SDL_FALSE;
 

--- a/src/video/playdate/SDL_playdate_framebuffer.c
+++ b/src/video/playdate/SDL_playdate_framebuffer.c
@@ -28,6 +28,7 @@
 #include "SDL_playdate_framebuffer_c.h"
 
 #include "pd_api.h"
+extern PlaydateAPI* pd;
 
 #define PLAYDATE_SURFACE   "_SDL_PlaydateSurface"
 

--- a/src/video/yuv2rgb/yuv_rgb.c
+++ b/src/video/yuv2rgb/yuv_rgb.c
@@ -1,0 +1,724 @@
+// Copyright 2016 Adrien Descamps
+// Distributed under BSD 3-Clause License
+#include "../../SDL_internal.h"
+
+#if SDL_HAVE_YUV
+
+#include "yuv_rgb.h"
+
+#include "SDL_cpuinfo.h"
+/*#include <x86intrin.h>*/
+
+#define PRECISION 6
+#define PRECISION_FACTOR (1<<PRECISION)
+
+typedef struct
+{
+	uint8_t y_shift;
+	int16_t matrix[3][3];
+} RGB2YUVParam;
+// |Y|   |y_shift|                        |matrix[0][0] matrix[0][1] matrix[0][2]|   |R|
+// |U| = |  128  | + 1/PRECISION_FACTOR * |matrix[1][0] matrix[1][1] matrix[1][2]| * |G|
+// |V|   |  128  |                        |matrix[2][0] matrix[2][1] matrix[2][2]|   |B|
+
+typedef struct
+{
+	uint8_t y_shift;
+	int16_t y_factor;
+	int16_t v_r_factor;
+	int16_t u_g_factor;
+	int16_t v_g_factor;
+	int16_t u_b_factor;
+} YUV2RGBParam;
+// |R|                        |y_factor      0       v_r_factor|   |Y-y_shift|
+// |G| = 1/PRECISION_FACTOR * |y_factor  u_g_factor  v_g_factor| * |  U-128  |
+// |B|                        |y_factor  u_b_factor      0     |   |  V-128  |
+
+#define V(value) (int16_t)((value*PRECISION_FACTOR)+0.5)
+
+// for ITU-T T.871, values can be found in section 7
+// for ITU-R BT.601-7 values are derived from equations in sections 2.5.1-2.5.3, assuming RGB is encoded using full range ([0-1]<->[0-255])
+// for ITU-R BT.709-6 values are derived from equations in sections 3.2-3.4, assuming RGB is encoded using full range ([0-1]<->[0-255])
+// all values are rounded to the fourth decimal
+
+static const YUV2RGBParam YUV2RGB[3] = {
+	// ITU-T T.871 (JPEG)
+	{/*.y_shift=*/ 0, /*.y_factor=*/ V(1.0), /*.v_r_factor=*/ V(1.402), /*.u_g_factor=*/ -V(0.3441), /*.v_g_factor=*/ -V(0.7141), /*.u_b_factor=*/ V(1.772)},
+	// ITU-R BT.601-7
+	{/*.y_shift=*/ 16, /*.y_factor=*/ V(1.1644), /*.v_r_factor=*/ V(1.596), /*.u_g_factor=*/ -V(0.3918), /*.v_g_factor=*/ -V(0.813), /*.u_b_factor=*/ V(2.0172)},
+	// ITU-R BT.709-6
+	{/*.y_shift=*/ 16, /*.y_factor=*/ V(1.1644), /*.v_r_factor=*/ V(1.7927), /*.u_g_factor=*/ -V(0.2132), /*.v_g_factor=*/ -V(0.5329), /*.u_b_factor=*/ V(2.1124)}
+};
+
+static const RGB2YUVParam RGB2YUV[3] = {
+	// ITU-T T.871 (JPEG)
+	{/*.y_shift=*/ 0, /*.matrix=*/ {{V(0.299), V(0.587), V(0.114)}, {-V(0.1687), -V(0.3313), V(0.5)}, {V(0.5), -V(0.4187), -V(0.0813)}}},
+	// ITU-R BT.601-7
+	{/*.y_shift=*/ 16, /*.matrix=*/ {{V(0.2568), V(0.5041), V(0.0979)}, {-V(0.1482), -V(0.291), V(0.4392)}, {V(0.4392), -V(0.3678), -V(0.0714)}}},
+	// ITU-R BT.709-6
+	{/*.y_shift=*/ 16, /*.matrix=*/ {{V(0.1826), V(0.6142), V(0.062)}, {-V(0.1006), -V(0.3386), V(0.4392)}, {V(0.4392), -V(0.3989), -V(0.0403)}}}
+};
+
+/* The various layouts of YUV data we support */
+#define YUV_FORMAT_420	1
+#define YUV_FORMAT_422	2
+#define YUV_FORMAT_NV12	3
+
+/* The various formats of RGB pixel that we support */
+#define RGB_FORMAT_RGB565	1
+#define RGB_FORMAT_RGB24	2
+#define RGB_FORMAT_RGBA		3
+#define RGB_FORMAT_BGRA		4
+#define RGB_FORMAT_ARGB		5
+#define RGB_FORMAT_ABGR		6
+
+// divide by PRECISION_FACTOR and clamp to [0:255] interval
+// input must be in the [-128*PRECISION_FACTOR:384*PRECISION_FACTOR] range
+static uint8_t clampU8(int32_t v)
+{
+	static const uint8_t lut[512] = 
+	{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+	0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,
+	47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,
+	91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,
+	126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,
+	159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,
+	192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,
+	225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,
+	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
+	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255
+	};
+	return lut[((v+128*PRECISION_FACTOR)>>PRECISION)&511];
+}
+
+
+#define STD_FUNCTION_NAME	yuv420_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv420_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv420_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv420_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv420_argb_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv420_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv422_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv422_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv422_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv422_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv422_argb_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuv422_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuvnv12_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuvnv12_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuvnv12_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuvnv12_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuvnv12_argb_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#include "yuv_rgb_std_func.h"
+
+#define STD_FUNCTION_NAME	yuvnv12_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#include "yuv_rgb_std_func.h"
+
+void rgb24_yuv420_std(
+	uint32_t width, uint32_t height, 
+	const uint8_t *RGB, uint32_t RGB_stride, 
+	uint8_t *Y, uint8_t *U, uint8_t *V, uint32_t Y_stride, uint32_t UV_stride, 
+	YCbCrType yuv_type)
+{
+	const RGB2YUVParam *const param = &(RGB2YUV[yuv_type]);
+	
+	uint32_t x, y;
+	for(y=0; y<(height-1); y+=2)
+	{
+		const uint8_t *rgb_ptr1=RGB+y*RGB_stride,
+			*rgb_ptr2=RGB+(y+1)*RGB_stride;
+			
+		uint8_t *y_ptr1=Y+y*Y_stride,
+			*y_ptr2=Y+(y+1)*Y_stride,
+			*u_ptr=U+(y/2)*UV_stride,
+			*v_ptr=V+(y/2)*UV_stride;
+		
+		for(x=0; x<(width-1); x+=2)
+		{
+			// compute yuv for the four pixels, u and v values are summed
+			int32_t y_tmp, u_tmp, v_tmp;
+			
+			y_tmp = param->matrix[0][0]*rgb_ptr1[0] + param->matrix[0][1]*rgb_ptr1[1] + param->matrix[0][2]*rgb_ptr1[2];
+			u_tmp = param->matrix[1][0]*rgb_ptr1[0] + param->matrix[1][1]*rgb_ptr1[1] + param->matrix[1][2]*rgb_ptr1[2];
+			v_tmp = param->matrix[2][0]*rgb_ptr1[0] + param->matrix[2][1]*rgb_ptr1[1] + param->matrix[2][2]*rgb_ptr1[2];
+			y_ptr1[0]=clampU8(y_tmp+((param->y_shift)<<PRECISION));
+			
+			y_tmp = param->matrix[0][0]*rgb_ptr1[3] + param->matrix[0][1]*rgb_ptr1[4] + param->matrix[0][2]*rgb_ptr1[5];
+			u_tmp += param->matrix[1][0]*rgb_ptr1[3] + param->matrix[1][1]*rgb_ptr1[4] + param->matrix[1][2]*rgb_ptr1[5];
+			v_tmp += param->matrix[2][0]*rgb_ptr1[3] + param->matrix[2][1]*rgb_ptr1[4] + param->matrix[2][2]*rgb_ptr1[5];
+			y_ptr1[1]=clampU8(y_tmp+((param->y_shift)<<PRECISION));
+			
+			y_tmp = param->matrix[0][0]*rgb_ptr2[0] + param->matrix[0][1]*rgb_ptr2[1] + param->matrix[0][2]*rgb_ptr2[2];
+			u_tmp += param->matrix[1][0]*rgb_ptr2[0] + param->matrix[1][1]*rgb_ptr2[1] + param->matrix[1][2]*rgb_ptr2[2];
+			v_tmp += param->matrix[2][0]*rgb_ptr2[0] + param->matrix[2][1]*rgb_ptr2[1] + param->matrix[2][2]*rgb_ptr2[2];
+			y_ptr2[0]=clampU8(y_tmp+((param->y_shift)<<PRECISION));
+			
+			y_tmp = param->matrix[0][0]*rgb_ptr2[3] + param->matrix[0][1]*rgb_ptr2[4] + param->matrix[0][2]*rgb_ptr2[5];
+			u_tmp += param->matrix[1][0]*rgb_ptr2[3] + param->matrix[1][1]*rgb_ptr2[4] + param->matrix[1][2]*rgb_ptr2[5];
+			v_tmp += param->matrix[2][0]*rgb_ptr2[3] + param->matrix[2][1]*rgb_ptr2[4] + param->matrix[2][2]*rgb_ptr2[5];
+			y_ptr2[1]=clampU8(y_tmp+((param->y_shift)<<PRECISION));
+			
+			u_ptr[0] = clampU8(u_tmp/4+(128<<PRECISION));
+			v_ptr[0] = clampU8(v_tmp/4+(128<<PRECISION));
+			
+			rgb_ptr1 += 6;
+			rgb_ptr2 += 6;
+			y_ptr1 += 2;
+			y_ptr2 += 2;
+			u_ptr += 1;
+			v_ptr += 1;
+		}
+	}
+}
+
+#ifdef __SSE2__
+
+#define SSE_FUNCTION_NAME	yuv420_rgb565_sse
+#define STD_FUNCTION_NAME	yuv420_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_rgb565_sseu
+#define STD_FUNCTION_NAME	yuv420_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_rgb24_sse
+#define STD_FUNCTION_NAME	yuv420_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_rgb24_sseu
+#define STD_FUNCTION_NAME	yuv420_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_rgba_sse
+#define STD_FUNCTION_NAME	yuv420_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_rgba_sseu
+#define STD_FUNCTION_NAME	yuv420_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_bgra_sse
+#define STD_FUNCTION_NAME	yuv420_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_bgra_sseu
+#define STD_FUNCTION_NAME	yuv420_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_argb_sse
+#define STD_FUNCTION_NAME	yuv420_argb_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_argb_sseu
+#define STD_FUNCTION_NAME	yuv420_argb_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_abgr_sse
+#define STD_FUNCTION_NAME	yuv420_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv420_abgr_sseu
+#define STD_FUNCTION_NAME	yuv420_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_rgb565_sse
+#define STD_FUNCTION_NAME	yuv422_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_rgb565_sseu
+#define STD_FUNCTION_NAME	yuv422_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_rgb24_sse
+#define STD_FUNCTION_NAME	yuv422_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_rgb24_sseu
+#define STD_FUNCTION_NAME	yuv422_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_rgba_sse
+#define STD_FUNCTION_NAME	yuv422_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_rgba_sseu
+#define STD_FUNCTION_NAME	yuv422_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_bgra_sse
+#define STD_FUNCTION_NAME	yuv422_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_bgra_sseu
+#define STD_FUNCTION_NAME	yuv422_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_argb_sse
+#define STD_FUNCTION_NAME	yuv422_argb_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_argb_sseu
+#define STD_FUNCTION_NAME	yuv422_argb_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_abgr_sse
+#define STD_FUNCTION_NAME	yuv422_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuv422_abgr_sseu
+#define STD_FUNCTION_NAME	yuv422_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_422
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_rgb565_sse
+#define STD_FUNCTION_NAME	yuvnv12_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_rgb565_sseu
+#define STD_FUNCTION_NAME	yuvnv12_rgb565_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGB565
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_rgb24_sse
+#define STD_FUNCTION_NAME	yuvnv12_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_rgb24_sseu
+#define STD_FUNCTION_NAME	yuvnv12_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_rgba_sse
+#define STD_FUNCTION_NAME	yuvnv12_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_rgba_sseu
+#define STD_FUNCTION_NAME	yuvnv12_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_bgra_sse
+#define STD_FUNCTION_NAME	yuvnv12_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_bgra_sseu
+#define STD_FUNCTION_NAME	yuvnv12_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_argb_sse
+#define STD_FUNCTION_NAME	yuvnv12_argb_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_argb_sseu
+#define STD_FUNCTION_NAME	yuvnv12_argb_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_abgr_sse
+#define STD_FUNCTION_NAME	yuvnv12_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#define SSE_ALIGNED
+#include "yuv_rgb_sse_func.h"
+
+#define SSE_FUNCTION_NAME	yuvnv12_abgr_sseu
+#define STD_FUNCTION_NAME	yuvnv12_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_NV12
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#include "yuv_rgb_sse_func.h"
+
+
+#define UNPACK_RGB24_32_STEP1(RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, R1, R2, G1, G2, B1, B2) \
+R1 = _mm_unpacklo_epi8(RGB1, RGB4); \
+R2 = _mm_unpackhi_epi8(RGB1, RGB4); \
+G1 = _mm_unpacklo_epi8(RGB2, RGB5); \
+G2 = _mm_unpackhi_epi8(RGB2, RGB5); \
+B1 = _mm_unpacklo_epi8(RGB3, RGB6); \
+B2 = _mm_unpackhi_epi8(RGB3, RGB6);
+
+#define UNPACK_RGB24_32_STEP2(RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, R1, R2, G1, G2, B1, B2) \
+RGB1 = _mm_unpacklo_epi8(R1, G2); \
+RGB2 = _mm_unpackhi_epi8(R1, G2); \
+RGB3 = _mm_unpacklo_epi8(R2, B1); \
+RGB4 = _mm_unpackhi_epi8(R2, B1); \
+RGB5 = _mm_unpacklo_epi8(G1, B2); \
+RGB6 = _mm_unpackhi_epi8(G1, B2); \
+
+#define UNPACK_RGB24_32(RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, R1, R2, G1, G2, B1, B2) \
+UNPACK_RGB24_32_STEP1(RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, R1, R2, G1, G2, B1, B2) \
+UNPACK_RGB24_32_STEP2(RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, R1, R2, G1, G2, B1, B2) \
+UNPACK_RGB24_32_STEP1(RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, R1, R2, G1, G2, B1, B2) \
+UNPACK_RGB24_32_STEP2(RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, R1, R2, G1, G2, B1, B2) \
+UNPACK_RGB24_32_STEP1(RGB1, RGB2, RGB3, RGB4, RGB5, RGB6, R1, R2, G1, G2, B1, B2) \
+
+#define RGB2YUV_16(R, G, B, Y, U, V) \
+Y = _mm_add_epi16(_mm_mullo_epi16(R, _mm_set1_epi16(param->matrix[0][0])), \
+		_mm_mullo_epi16(G, _mm_set1_epi16(param->matrix[0][1]))); \
+Y = _mm_add_epi16(Y, _mm_mullo_epi16(B, _mm_set1_epi16(param->matrix[0][2]))); \
+Y = _mm_add_epi16(Y, _mm_set1_epi16((param->y_shift)<<PRECISION)); \
+Y = _mm_srai_epi16(Y, PRECISION); \
+U = _mm_add_epi16(_mm_mullo_epi16(R, _mm_set1_epi16(param->matrix[1][0])), \
+		_mm_mullo_epi16(G, _mm_set1_epi16(param->matrix[1][1]))); \
+U = _mm_add_epi16(U, _mm_mullo_epi16(B, _mm_set1_epi16(param->matrix[1][2]))); \
+U = _mm_add_epi16(U, _mm_set1_epi16(128<<PRECISION)); \
+U = _mm_srai_epi16(U, PRECISION); \
+V = _mm_add_epi16(_mm_mullo_epi16(R, _mm_set1_epi16(param->matrix[2][0])), \
+		_mm_mullo_epi16(G, _mm_set1_epi16(param->matrix[2][1]))); \
+V = _mm_add_epi16(V, _mm_mullo_epi16(B, _mm_set1_epi16(param->matrix[2][2]))); \
+V = _mm_add_epi16(V, _mm_set1_epi16(128<<PRECISION)); \
+V = _mm_srai_epi16(V, PRECISION);
+
+#define RGB2YUV_32 \
+	__m128i r1, r2, b1, b2, g1, g2; \
+	__m128i r_16, g_16, b_16; \
+	__m128i y1_16, y2_16, u1_16, u2_16, v1_16, v2_16, y, u1, u2, v1, v2, u1_tmp, u2_tmp, v1_tmp, v2_tmp; \
+	__m128i rgb1 = LOAD_SI128((const __m128i*)(rgb_ptr1)), \
+		rgb2 = LOAD_SI128((const __m128i*)(rgb_ptr1+16)), \
+		rgb3 = LOAD_SI128((const __m128i*)(rgb_ptr1+32)), \
+		rgb4 = LOAD_SI128((const __m128i*)(rgb_ptr2)), \
+		rgb5 = LOAD_SI128((const __m128i*)(rgb_ptr2+16)), \
+		rgb6 = LOAD_SI128((const __m128i*)(rgb_ptr2+32)); \
+	/* unpack rgb24 data to r, g and b data in separate channels*/ \
+	UNPACK_RGB24_32(rgb1, rgb2, rgb3, rgb4, rgb5, rgb6, r1, r2, g1, g2, b1, b2) \
+	/* process pixels of first line */ \
+	r_16 = _mm_unpacklo_epi8(r1, _mm_setzero_si128()); \
+	g_16 = _mm_unpacklo_epi8(g1, _mm_setzero_si128()); \
+	b_16 = _mm_unpacklo_epi8(b1, _mm_setzero_si128()); \
+	RGB2YUV_16(r_16, g_16, b_16, y1_16, u1_16, v1_16) \
+	r_16 = _mm_unpackhi_epi8(r1, _mm_setzero_si128()); \
+	g_16 = _mm_unpackhi_epi8(g1, _mm_setzero_si128()); \
+	b_16 = _mm_unpackhi_epi8(b1, _mm_setzero_si128()); \
+	RGB2YUV_16(r_16, g_16, b_16, y2_16, u2_16, v2_16) \
+	y = _mm_packus_epi16(y1_16, y2_16); \
+	u1 = _mm_packus_epi16(u1_16, u2_16); \
+	v1 = _mm_packus_epi16(v1_16, v2_16); \
+	/* save Y values */ \
+	SAVE_SI128((__m128i*)(y_ptr1), y); \
+	/* process pixels of second line */ \
+	r_16 = _mm_unpacklo_epi8(r2, _mm_setzero_si128()); \
+	g_16 = _mm_unpacklo_epi8(g2, _mm_setzero_si128()); \
+	b_16 = _mm_unpacklo_epi8(b2, _mm_setzero_si128()); \
+	RGB2YUV_16(r_16, g_16, b_16, y1_16, u1_16, v1_16) \
+	r_16 = _mm_unpackhi_epi8(r2, _mm_setzero_si128()); \
+	g_16 = _mm_unpackhi_epi8(g2, _mm_setzero_si128()); \
+	b_16 = _mm_unpackhi_epi8(b2, _mm_setzero_si128()); \
+	RGB2YUV_16(r_16, g_16, b_16, y2_16, u2_16, v2_16) \
+	y = _mm_packus_epi16(y1_16, y2_16); \
+	u2 = _mm_packus_epi16(u1_16, u2_16); \
+	v2 = _mm_packus_epi16(v1_16, v2_16); \
+	/* save Y values */ \
+	SAVE_SI128((__m128i*)(y_ptr2), y); \
+	/* vertical subsampling of u/v values */ \
+	u1_tmp = _mm_avg_epu8(u1, u2); \
+	v1_tmp = _mm_avg_epu8(v1, v2); \
+	/* do the same again with next data */ \
+	rgb1 = LOAD_SI128((const __m128i*)(rgb_ptr1+48)); \
+	rgb2 = LOAD_SI128((const __m128i*)(rgb_ptr1+64)); \
+	rgb3 = LOAD_SI128((const __m128i*)(rgb_ptr1+80)); \
+	rgb4 = LOAD_SI128((const __m128i*)(rgb_ptr2+48)); \
+	rgb5 = LOAD_SI128((const __m128i*)(rgb_ptr2+64)); \
+	rgb6 = LOAD_SI128((const __m128i*)(rgb_ptr2+80)); \
+	/* unpack rgb24 data to r, g and b data in separate channels*/ \
+	UNPACK_RGB24_32(rgb1, rgb2, rgb3, rgb4, rgb5, rgb6, r1, r2, g1, g2, b1, b2) \
+	/* process pixels of first line */ \
+	r_16 = _mm_unpacklo_epi8(r1, _mm_setzero_si128()); \
+	g_16 = _mm_unpacklo_epi8(g1, _mm_setzero_si128()); \
+	b_16 = _mm_unpacklo_epi8(b1, _mm_setzero_si128()); \
+	RGB2YUV_16(r_16, g_16, b_16, y1_16, u1_16, v1_16) \
+	r_16 = _mm_unpackhi_epi8(r1, _mm_setzero_si128()); \
+	g_16 = _mm_unpackhi_epi8(g1, _mm_setzero_si128()); \
+	b_16 = _mm_unpackhi_epi8(b1, _mm_setzero_si128()); \
+	RGB2YUV_16(r_16, g_16, b_16, y2_16, u2_16, v2_16) \
+	y = _mm_packus_epi16(y1_16, y2_16); \
+	u1 = _mm_packus_epi16(u1_16, u2_16); \
+	v1 = _mm_packus_epi16(v1_16, v2_16); \
+	/* save Y values */ \
+	SAVE_SI128((__m128i*)(y_ptr1+16), y); \
+	/* process pixels of second line */ \
+	r_16 = _mm_unpacklo_epi8(r2, _mm_setzero_si128()); \
+	g_16 = _mm_unpacklo_epi8(g2, _mm_setzero_si128()); \
+	b_16 = _mm_unpacklo_epi8(b2, _mm_setzero_si128()); \
+	RGB2YUV_16(r_16, g_16, b_16, y1_16, u1_16, v1_16) \
+	r_16 = _mm_unpackhi_epi8(r2, _mm_setzero_si128()); \
+	g_16 = _mm_unpackhi_epi8(g2, _mm_setzero_si128()); \
+	b_16 = _mm_unpackhi_epi8(b2, _mm_setzero_si128()); \
+	RGB2YUV_16(r_16, g_16, b_16, y2_16, u2_16, v2_16) \
+	y = _mm_packus_epi16(y1_16, y2_16); \
+	u2 = _mm_packus_epi16(u1_16, u2_16); \
+	v2 = _mm_packus_epi16(v1_16, v2_16); \
+	/* save Y values */ \
+	SAVE_SI128((__m128i*)(y_ptr2+16), y); \
+	/* vertical subsampling of u/v values */ \
+	u2_tmp = _mm_avg_epu8(u1, u2); \
+	v2_tmp = _mm_avg_epu8(v1, v2); \
+	/* horizontal subsampling of u/v values */ \
+	u1 = _mm_packus_epi16(_mm_srl_epi16(u1_tmp, _mm_cvtsi32_si128(8)), _mm_srl_epi16(u2_tmp, _mm_cvtsi32_si128(8))); \
+	v1 = _mm_packus_epi16(_mm_srl_epi16(v1_tmp, _mm_cvtsi32_si128(8)), _mm_srl_epi16(v2_tmp, _mm_cvtsi32_si128(8))); \
+	u2 = _mm_packus_epi16(_mm_and_si128(u1_tmp, _mm_set1_epi16(0xFF)), _mm_and_si128(u2_tmp, _mm_set1_epi16(0xFF))); \
+	v2 = _mm_packus_epi16(_mm_and_si128(v1_tmp, _mm_set1_epi16(0xFF)), _mm_and_si128(v2_tmp, _mm_set1_epi16(0xFF))); \
+	u1 = _mm_avg_epu8(u1, u2); \
+	v1 = _mm_avg_epu8(v1, v2); \
+	SAVE_SI128((__m128i*)(u_ptr), u1); \
+	SAVE_SI128((__m128i*)(v_ptr), v1);
+
+void rgb24_yuv420_sse(uint32_t width, uint32_t height, 
+	const uint8_t *RGB, uint32_t RGB_stride, 
+	uint8_t *Y, uint8_t *U, uint8_t *V, uint32_t Y_stride, uint32_t UV_stride, 
+	YCbCrType yuv_type)
+{
+	#define LOAD_SI128 _mm_load_si128
+	#define SAVE_SI128 _mm_stream_si128
+	const RGB2YUVParam *const param = &(RGB2YUV[yuv_type]);
+	
+	uint32_t xpos, ypos;
+	for(ypos=0; ypos<(height-1); ypos+=2)
+	{
+		const uint8_t *rgb_ptr1=RGB+ypos*RGB_stride,
+			*rgb_ptr2=RGB+(ypos+1)*RGB_stride;
+		
+		uint8_t *y_ptr1=Y+ypos*Y_stride,
+			*y_ptr2=Y+(ypos+1)*Y_stride,
+			*u_ptr=U+(ypos/2)*UV_stride,
+			*v_ptr=V+(ypos/2)*UV_stride;
+		
+		for(xpos=0; xpos<(width-31); xpos+=32)
+		{
+			RGB2YUV_32
+			
+			rgb_ptr1+=96;
+			rgb_ptr2+=96;
+			y_ptr1+=32;
+			y_ptr2+=32;
+			u_ptr+=16; 
+			v_ptr+=16;
+		}
+	}
+	#undef LOAD_SI128
+	#undef SAVE_SI128
+}
+
+void rgb24_yuv420_sseu(uint32_t width, uint32_t height, 
+	const uint8_t *RGB, uint32_t RGB_stride, 
+	uint8_t *Y, uint8_t *U, uint8_t *V, uint32_t Y_stride, uint32_t UV_stride, 
+	YCbCrType yuv_type)
+{
+	#define LOAD_SI128 _mm_loadu_si128
+	#define SAVE_SI128 _mm_storeu_si128
+	const RGB2YUVParam *const param = &(RGB2YUV[yuv_type]);
+	
+	uint32_t xpos, ypos;
+	for(ypos=0; ypos<(height-1); ypos+=2)
+	{
+		const uint8_t *rgb_ptr1=RGB+ypos*RGB_stride,
+			*rgb_ptr2=RGB+(ypos+1)*RGB_stride;
+		
+		uint8_t *y_ptr1=Y+ypos*Y_stride,
+			*y_ptr2=Y+(ypos+1)*Y_stride,
+			*u_ptr=U+(ypos/2)*UV_stride,
+			*v_ptr=V+(ypos/2)*UV_stride;
+		
+		for(xpos=0; xpos<(width-31); xpos+=32)
+		{
+			RGB2YUV_32
+			
+			rgb_ptr1+=96;
+			rgb_ptr2+=96;
+			y_ptr1+=32;
+			y_ptr2+=32;
+			u_ptr+=16; 
+			v_ptr+=16;
+		}
+	}
+	#undef LOAD_SI128
+	#undef SAVE_SI128
+}
+
+
+#endif //__SSE2__
+
+#ifdef __loongarch_sx
+
+#define LSX_FUNCTION_NAME	yuv420_rgb24_lsx
+#define STD_FUNCTION_NAME	yuv420_rgb24_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGB24
+#include "yuv_rgb_lsx_func.h"
+
+#define LSX_FUNCTION_NAME	yuv420_rgba_lsx
+#define STD_FUNCTION_NAME	yuv420_rgba_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_RGBA
+#include "yuv_rgb_lsx_func.h"
+
+#define LSX_FUNCTION_NAME	yuv420_bgra_lsx
+#define STD_FUNCTION_NAME	yuv420_bgra_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_BGRA
+#include "yuv_rgb_lsx_func.h"
+
+#define LSX_FUNCTION_NAME	yuv420_argb_lsx
+#define STD_FUNCTION_NAME	yuv420_argb_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_ARGB
+#include "yuv_rgb_lsx_func.h"
+
+#define LSX_FUNCTION_NAME	yuv420_abgr_lsx
+#define STD_FUNCTION_NAME	yuv420_abgr_std
+#define YUV_FORMAT			YUV_FORMAT_420
+#define RGB_FORMAT			RGB_FORMAT_ABGR
+#include "yuv_rgb_lsx_func.h"
+
+#endif  //__loongarch_sx
+
+#endif /* SDL_HAVE_YUV */


### PR DESCRIPTION
Referenced pd_api.h in the files required to compile SDL2 libs for Playdate

## Description
In addition to the `extern PlaydateAPI* pd;` addition, I added  Added timestamp_us and millisecond counter to SDL_PrivateSensorUpdate, and added back yuv2rgb.c in reference to the makefile [here](https://github.com/libsdl-org/SDL/pull/5474#issuecomment-1090501564)

## Existing Issue(s)
Made this as what was needed for compile SDL for playdate and as a log for what changes I already made.
